### PR TITLE
Make MinecraftPinger ctor take ushort instead of short for port

### DIFF
--- a/src/MCServerStatus/MinecraftPinger.cs
+++ b/src/MCServerStatus/MinecraftPinger.cs
@@ -13,9 +13,9 @@ namespace MCServerStatus
     public class MinecraftPinger : IMinecraftPinger
     {
         private string Address { get; }
-        private short Port { get; }
+        private ushort Port { get; }
 
-        public MinecraftPinger(string address, short port)
+        public MinecraftPinger(string address, ushort port)
         {
             Address = address;
             Port = port;


### PR DESCRIPTION
This allows to ping servers whose port are >32767